### PR TITLE
chore: enable mise lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ The project is organized as follows, with each directory and file intended to se
     ├── .dockerignore          <- Ignore rules for Docker builds.
     ├── .envrc                 <- Environmental variable loaded by direnv.
     ├── .gitignore             <- Ignore rules for Git version control.
-    ├── mise.toml             <- Project tool/runtime configuration for mise.
+    ├── mise.lock              <- Pins exact versions and checksums of tools for mise.   
+    ├── mise.toml              <- Project tool/runtime configuration for mise.
     ├── LICENSE                <- Project license.
     ├── pyproject.toml         <- Python project metadata and dependency configuration.
     ├── README.md              <- Top-level project documentation for developers.

--- a/mise.lock
+++ b/mise.lock
@@ -1,0 +1,17 @@
+[[tools.python]]
+version = "3.13.7"
+backend = "core:python"
+
+[[tools.uv]]
+version = "0.8.17"
+backend = "aqua:astral-sh/uv"
+
+[tools.uv.platforms.linux-arm64]
+checksum = "sha256:bd141b7e263935d14f5725f2a5c1c942fd89642e37683cb904f1984ce7e365f4"
+size = 19553086
+url = "https://github.com/astral-sh/uv/releases/download/0.8.17/uv-aarch64-unknown-linux-musl.tar.gz"
+
+[tools.uv.platforms.macos-arm64]
+checksum = "sha256:e4d4859d7726298daa4c12e114f269ff282b2cfc2b415dc0b2ca44ae2dbd358e"
+size = 17968067
+url = "https://github.com/astral-sh/uv/releases/download/0.8.17/uv-aarch64-apple-darwin.tar.gz"

--- a/mise.toml
+++ b/mise.toml
@@ -1,9 +1,13 @@
 [tools]
-python = "3.13.7"
-uv = "0.8.17"
+python = "3.13"
+uv = "0.8"
 
 [env]
 UV_PROJECT_ENV = ".venv"
+
+[settings]
+experimental=true
+lockfile = true
 
 [tasks.ruff-format]
 run = "uv run ruff format src tests"


### PR DESCRIPTION
## Summary

- enable mise lockfile support to pin tool versions (https://mise.jdx.dev/dev-tools/mise-lock.html)
- add generated mise.lock file
- document the lockfile in the README